### PR TITLE
Fix REG syntax package syntax highlight being replaced by nothing

### DIFF
--- a/icons/icons.json
+++ b/icons/icons.json
@@ -1384,13 +1384,9 @@
   },
   "file_type_registry": {
     "color": "sky",
-    "aliases": [
+    "syntaxes": [
       {
         "name": "Registry (REG)",
-        "extensions": [
-          "reg"
-        ],
-        "base": "source.ini",
         "scope": "source.reg"
       }
     ]


### PR DESCRIPTION
When the package https://github.com/robertcollier4/REG is installed, its syntax is not applied as it is replaced by a blank syntax with no coloring.

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
