### PR TITLE
Add icon to nameless .sublime-project

### DIFF
--- a/icons/icons.json
+++ b/icons/icons.json
@@ -1637,6 +1637,7 @@
 				"name": "JSON (Sublime)",
 				"linter": "json",
 				"extensions": [
+					".sublime-project",
 					".no-sublime-package",
 					"hidden-color-scheme",
 					"hidden-theme",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

#### Description
<!-- Describe your changes in detail -->
A `.sublime-project` without a name (i.e. as a dotfile) should have an icon too.

#### Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
I'm not naming my sublime-project files because the folder already contains the project name and omitting the name moves it up to all the other dotfiles in the sidebar, which implicitly groups all configuration files together.

#### How Has This Been Tested?
<!-- Please describe in detail how you tested your changes. -->
<!-- See how your change affects other areas of the code, etc. -->
I just reinstalled the plugin (to regenerate the 'zzz A File Icon zzz' package) and it worked. There shouldn't be any more testing required.

#### Screenshots (if appropriate):

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
