### PR TITLE
Fix `npmrc` syntax alias

### DIFF
--- a/icons/icons.json
+++ b/icons/icons.json
@@ -2086,11 +2086,19 @@
 			{
 				"base": "source.shell",
 				"extensions": [
-					".npmignore",
-					".npmrc"
+					".npmignore"
 				],
 				"name": "Shell Script (NPM)",
 				"scope": "source.shell.npm"
+			},
+			{
+				"base": "source.ini",
+				"extensions": [
+					".npmrc",
+					"npmrc"
+				],
+				"name": "Plain Text (NPM)",
+				"scope": "source.ini.npm"
 			},
 			{
 				"base": "source.json",

--- a/preferences/file_type_npm.tmPreferences
+++ b/preferences/file_type_npm.tmPreferences
@@ -2,7 +2,7 @@
 <plist version="1.0">
 	<dict>
 		<key>scope</key>
-		<string>source.json.npm, source.shell.npm</string>
+		<string>source.ini.npm, source.json.npm, source.shell.npm</string>
 		<key>settings</key>
 		<dict>
 			<key>icon</key>


### PR DESCRIPTION
#### Description

As it's actually INI.

#### Motivation and Context

Invalid syntax in `npmrc` files - see [documentation](https://docs.npmjs.com/cli/v10/configuring-npm/npmrc).

#### How Has This Been Tested?

- `tests/.npmrc`
- `tests/npmrc`

#### Types of changes
<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

#### Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [x] I have read the **CONTRIBUTING** document.
