### PR TITLE
Add pubspec.lock as a YAML lockfile

### DIFF
--- a/icons/icons.json
+++ b/icons/icons.json
@@ -1880,6 +1880,7 @@
 			{
 				"base": "source.yaml",
 				"extensions": [
+					"pubspec.lock",
 					"yarn.lock"
 				],
 				"name": "YAML (Lock)",


### PR DESCRIPTION
Adds detection of pubspec.lock as a lockfile with YAML syntax. This is used by Dart projects.

See:
- https://dart.dev/tools/pub/private-files#pubspec-lock
- https://dart.dev/resources/glossary#lockfile
